### PR TITLE
Adapt blacklist for PO2015

### DIFF
--- a/vv_exporter.py
+++ b/vv_exporter.py
@@ -13,13 +13,15 @@ warnings.simplefilter('ignore', UserWarning)
 # VVs again and again and again and again and again and again and ...)
 BLACKLIST = (
     'Weitere Veranstaltungen',
-    'Leistungen für den Masterstudiengang',
+    'Leistungen für den Masterstudiengang',  # PO 2009
+    'Vorgezogene Masterleistungen',          # PO 2015
     'Zusätzliche Leistungen',
     'Anmelden',
     'Gesamtkatalog aller Module an der TU Darmstadt',
     'Informatik fachübergreifend',
     'Module des Sprachenzentrums mit Fachprüfungen',
-    'Fachübergreifende Veranstaltungen',
+    'Fachübergreifende Veranstaltungen',     # PO 2009
+    'Fachübergreifende Lehrveranstaltungen', # PO 2015
     'Veranstaltung'
 )
 


### PR DESCRIPTION
The names of the links in Tucan are different for PO2015 and PO2009. This pull request adds PO2015 link-equivalents to the Blacklist.